### PR TITLE
Fix typo in manifest

### DIFF
--- a/src/Snipe.chromeextension/manifest.json
+++ b/src/Snipe.chromeextension/manifest.json
@@ -12,7 +12,7 @@
     },
     "omnibox": { "keyword" : "tabs" },
     "browser_action": {
-        "default_icon": "images/icon-19.png",
+        "default_icon": "images/Icon-19.png",
         "default_title": "Snipe",
         "default_popup": "popup.html"
     },


### PR DESCRIPTION
Manifest references "images/icon-19.png", but the actual filename is "images/Icon-19.png".
